### PR TITLE
Fix total money not being shown in MVM

### DIFF
--- a/_voidhud/scripts/hudlayout.res
+++ b/_voidhud/scripts/hudlayout.res
@@ -484,4 +484,18 @@
 		"wide"					"640"
 		"tall"					"100"
 	}
+	
+	"CurrencyStatusPanel"
+	{
+		"ControlName"		"CCurrencyStatusPanel"
+		"fieldName"			"CurrencyStatusPanel"
+		"xpos"				"c-185"
+		"ypos"				"r65"
+		"wide"				"100"
+		"tall"				"100"
+		"xpos_minbad"		"65"
+		"ypos_minbad"		"r88"
+		"visible" 			"1"
+		"enabled" 			"1"
+	}
 }


### PR DESCRIPTION
This fixes an issue where the total amount of money in MVM is not being shown. This was an issue with the last few HUDs I've used, which makes me suspect it's because of a recent update/patch that many HUD maintainers haven't thoroughly inspected

Here's the HUD before:
![hl2_exMcbxHpSh](https://github.com/cjrose/voidHUD/assets/69414142/06c1c96b-a328-47ad-bd95-5724d04b1a5c)

And after:
![hl2_n25jzzCyrg](https://github.com/cjrose/voidHUD/assets/69414142/ef052723-666e-42c8-83d3-75f93173312b)
